### PR TITLE
[DOC channel]Fixed URL for Browserstack Icon fixes issue #17724

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ See [CONTRIBUTING.md](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTI
 
 Cross-browser testing provided by:
 
-<a href="http://browserstack.com"><img height="70" src="ttp://www.browserstack.com/images/layout/browserstack-logo-600x315.png" alt="BrowserStack"></a>
+<a href="http://browserstack.com"><img height="70" src="http://www.browserstack.com/images/layout/browserstack-logo-600x315.png" alt="BrowserStack"></a>

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ See [CONTRIBUTING.md](https://github.com/emberjs/ember.js/blob/master/CONTRIBUTI
 
 Cross-browser testing provided by:
 
-<a href="http://browserstack.com"><img height="70" src="https://p3.zdusercontent.com/attachment/1015988/PWfFdN71Aung2evRkIVQuKJpE?token=eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0..aUrNFb8clSXsFwgw5BUTcg.IJr5piuCen7PmSSBHSrOnqM9K5YZfxX3lvbp-5LCqoKOi4CjjgdA419iqjofs0nLtm26FMURvZ8JRTuKB4iHer6lGu5f8dXHtIkYAHjP5fXDWkl044Yg2mSdrhF6uPy62GdlBYoYxwvgkNrac8nN_In8GY-qOC7bYmlZyJT7tsTZUTYbNMQiXS86YA5LgdCEWzWreMvc3C6cvZtVXIrcVgpkroIhvsTQPm4vQA-Uq6iCbTPA4oX5cpEtMtrlg4jYBnnAE4BTw5UwU_dY83ep5g.7wpc1IKv0rSRGsvqCG_q3g" alt="BrowserStack"></a>
+<a href="http://browserstack.com"><img height="70" src="ttp://www.browserstack.com/images/layout/browserstack-logo-600x315.png" alt="BrowserStack"></a>


### PR DESCRIPTION
Fixed the BrowserStack logo url in the Readme